### PR TITLE
Improve CSV handling and add regression

### DIFF
--- a/notebooks/01_data_load.ipynb
+++ b/notebooks/01_data_load.ipynb
@@ -38,7 +38,7 @@
     "# In diesem Schritt holen wir uns historische Kursdaten\n",
     "# (OHLCV = Open, High, Low, Close, Volume) von Yahoo Finance.\n",
     "# Wir \"frieren\" den Datensatz dann als CSV ein, damit er in allen\n",
-    "# späteren Schritten reproduzierbar bleibt.\n",
+    "# sp\u00e4teren Schritten reproduzierbar bleibt.\n",
     "# -----------------------------------------"
    ]
   },
@@ -65,7 +65,7 @@
     "# TICKER   = Symbol des Assets\n",
     "# START    = Startdatum\n",
     "# END      = Enddatum\n",
-    "# INTERVAL = Zeitintervall ('1d' = täglich, '1h' = stündlich, ...)"
+    "# INTERVAL = Zeitintervall ('1d' = t\u00e4glich, '1h' = st\u00fcndlich, ...)"
    ]
   },
   {
@@ -88,8 +88,8 @@
    "metadata": {},
    "source": [
     "# ---- Daten laden ----\n",
-    "# auto_adjust=True sorgt dafür, dass Kurse um Splits & Dividenden bereinigt sind.\n",
-    "# Ohne diese Adjustierung würde das Modell \"falsche\" Sprünge sehen."
+    "# auto_adjust=True sorgt daf\u00fcr, dass Kurse um Splits & Dividenden bereinigt sind.\n",
+    "# Ohne diese Adjustierung w\u00fcrde das Modell \"falsche\" Spr\u00fcnge sehen."
    ]
   },
   {
@@ -132,7 +132,13 @@
     "    \"Low\": \"low\",\n",
     "    \"Close\": \"close\",\n",
     "    \"Volume\": \"volume\"\n",
-    "}).dropna()"
+    "}).dropna()\n",
+    "\n",
+    "if isinstance(df.columns, pd.MultiIndex):\n",
+    "    df.columns = df.columns.get_level_values(-1)\n",
+    "\n",
+    "df.columns.name = None\n",
+    "df.index.name = \"date\"\n"
    ]
   },
   {
@@ -161,7 +167,7 @@
       "2025-08-28  232.559998  233.410004  229.339996  230.820007  38074700\n",
       "2025-08-29  232.139999  233.380005  231.369995  232.509995  39418400 \n",
       "\n",
-      "Zeitraum: 2012-01-03 → 2025-08-29 | Anzahl Zeilen: 3435\n"
+      "Zeitraum: 2012-01-03 \u2192 2025-08-29 | Anzahl Zeilen: 3435\n"
      ]
     }
    ],
@@ -169,7 +175,7 @@
     "# ---- Erste Kontrolle ----\n",
     "print(\"Erste Zeilen:\\n\", df.head(3), \"\\n\")\n",
     "print(\"Letzte Zeilen:\\n\", df.tail(3), \"\\n\")\n",
-    "print(\"Zeitraum:\", df.index.min().date(), \"→\", df.index.max().date(), \"| Anzahl Zeilen:\", len(df))"
+    "print(\"Zeitraum:\", df.index.min().date(), \"\u2192\", df.index.max().date(), \"| Anzahl Zeilen:\", len(df))"
    ]
   },
   {
@@ -190,8 +196,8 @@
     }
    ],
    "source": [
-    "# ---- Plausibilitätscheck: Plot ----\n",
-    "# Wir plotten den Schlusskurs (close), um einen groben Überblick zu bekommen.\n",
+    "# ---- Plausibilit\u00e4tscheck: Plot ----\n",
+    "# Wir plotten den Schlusskurs (close), um einen groben \u00dcberblick zu bekommen.\n",
     "df[\"close\"].plot(title=f\"{TICKER} Close ({INTERVAL})\", figsize=(9,4))\n",
     "plt.show()"
    ]
@@ -212,8 +218,8 @@
    ],
    "source": [
     "# ---- CSV \"einfrieren\" ----\n",
-    "# Speicherung im Ordner ../data (eine Ebene über notebooks/)\n",
-    "# Vorteil: Reproduzierbarkeit – ab jetzt nutzen wir immer diesen Schnappschuss.\n",
+    "# Speicherung im Ordner ../data (eine Ebene \u00fcber notebooks/)\n",
+    "# Vorteil: Reproduzierbarkeit \u2013 ab jetzt nutzen wir immer diesen Schnappschuss.\n",
     "os.makedirs(\"../data\", exist_ok=True)\n",
     "csv_path = f\"../data/{TICKER}_{INTERVAL}_{START}_{END}.csv\"\n",
     "df.to_csv(csv_path)\n",
@@ -227,10 +233,10 @@
    "metadata": {},
    "source": [
     "# -----------------------------------------------------------\n",
-    "# Block 2: Zielvariable bauen – Klassifikation (Up/Down)\n",
+    "# Block 2: Zielvariable bauen \u2013 Klassifikation (Up/Down)\n",
     "# -----------------------------------------------------------\n",
-    "# Ziel: Für jeden Tag t sagen wir vorher, ob der Kurs in t+h\n",
-    "# (HORIZON) höher ist als in t. target = 1 (up) oder 0 (down).\n",
+    "# Ziel: F\u00fcr jeden Tag t sagen wir vorher, ob der Kurs in t+h\n",
+    "# (HORIZON) h\u00f6her ist als in t. target = 1 (up) oder 0 (down).\n",
     "# Wir arbeiten auf dem \"eingefrorenen\" CSV aus Block 1.\n",
     "# -----------------------------------------------------------\n",
     "# Horizon oben definieren\n",
@@ -251,52 +257,54 @@
     "# ---- 1) CSV ROBUST EINLESEN ----\n",
     "def read_prices(csv_path: str) -> pd.DataFrame:\n",
     "    import pandas as pd\n",
-    "    import numpy as np\n",
     "\n",
-    "    # 1) Normal versuchen\n",
-    "    df0 = pd.read_csv(csv_path, index_col=0)\n",
-    "\n",
-    "    # Helper: sichere Checks ohne NoneType-Fehler\n",
-    "    def has_ticker_in_colname(d):\n",
-    "        name = getattr(d.columns, \"name\", None)\n",
-    "        return isinstance(name, str) and (\"Ticker\" in name)\n",
-    "\n",
-    "    def has_ticker_row(d):\n",
-    "        # prüfe die ersten paar Indexeinträge als Strings\n",
-    "        head_idx = d.index[:5].astype(str).tolist()\n",
-    "        return any(s.strip().lower() == \"ticker\" for s in head_idx)\n",
-    "\n",
-    "    has_multi = isinstance(df0.columns, pd.MultiIndex)\n",
-    "    has_ticker_col = has_ticker_in_colname(df0)\n",
-    "    has_ticker_row = has_ticker_row(df0)\n",
-    "    has_ticker_in_cols = \"Ticker\" in df0.columns.tolist()\n",
-    "\n",
-    "    if has_multi or has_ticker_col or has_ticker_row or has_ticker_in_cols:\n",
-    "        # 2) Re-Read mit zwei Kopfzeilen und erste Ebene behalten\n",
-    "        df1 = pd.read_csv(csv_path, index_col=0, header=[0, 1])\n",
-    "        df1.columns = df1.columns.get_level_values(0)\n",
-    "        df = df1\n",
-    "    else:\n",
-    "        df = df0\n",
-    "\n",
-    "    # 3) Index → Datum (alles was kein Datum ist, rausschmeißen)\n",
-    "    df.index = pd.to_datetime(df.index, errors=\"coerce\")\n",
+    "    df = pd.read_csv(csv_path, index_col=0, parse_dates=[0])\n",
+    "    df.index = pd.to_datetime(df.index, format=\"%Y-%m-%d\", errors=\"coerce\")\n",
     "    df = df[~df.index.isna()]\n",
     "\n",
-    "    # 4) Nur erwartete Spalten behalten\n",
-    "    keep = [\"open\", \"high\", \"low\", \"close\", \"volume\"]\n",
-    "    df = df[[c for c in keep if c in df.columns]].copy()\n",
+    "    df.columns = [str(c).lower() for c in df.columns]\n",
+    "    df.columns.name = None\n",
+    "    df.index.name = \"date\"\n",
     "\n",
-    "    # 5) Numerisch erzwingen\n",
+    "    keep = [\"open\", \"high\", \"low\", \"close\", \"volume\"]\n",
+    "    df = df[[c for c in df.columns if c in keep]].copy()\n",
+    "\n",
     "    for c in df.columns:\n",
     "        df[c] = pd.to_numeric(df[c], errors=\"coerce\")\n",
     "\n",
-    "    # 6) Reste ohne Zahlen entfernen\n",
     "    df = df.dropna(how=\"any\")\n",
     "\n",
     "    return df\n",
     "\n",
-    "df = read_prices(csv_in)"
+    "df = read_prices(csv_in)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ---- Regression: Legacy vs. neue CSV-Struktur ----\n",
+    "from pathlib import Path\n",
+    "import tempfile\n",
+    "import pandas as pd\n",
+    "\n",
+    "legacy_path = Path('../data/AAPL_1d_2012-01-01_2025-09-01.csv')\n",
+    "legacy_df = read_prices(legacy_path)\n",
+    "assert not legacy_df.empty, 'Legacy-CSV konnte nicht geladen werden'\n",
+    "\n",
+    "with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:\n",
+    "    legacy_df.head().to_csv(tmp.name)\n",
+    "    tmp_path = Path(tmp.name)\n",
+    "\n",
+    "try:\n",
+    "    fresh_df = read_prices(tmp_path)\n",
+    "    pd.testing.assert_frame_equal(fresh_df, legacy_df.head())\n",
+    "finally:\n",
+    "    tmp_path.unlink(missing_ok=True)\n",
+    "\n",
+    "print('Legacy-Zeilen:', legacy_df.shape, '| Neue CSV-Zeilen:', fresh_df.shape)\n"
    ]
   },
   {
@@ -323,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Aufräumen (erste diff-Zeile & letzte HORIZON-Zeilen)\n",
+    "# Aufr\u00e4umen (erste diff-Zeile & letzte HORIZON-Zeilen)\n",
     "df_clean = df.dropna().copy()"
    ]
   },
@@ -338,7 +346,7 @@
      "output_type": "stream",
      "text": [
       "Spalten: ['open', 'high', 'low', 'close', 'volume', 'logret_1d', 'target']\n",
-      "Zeitraum: 2012-01-04 → 2025-08-29 | n = 3434\n",
+      "Zeitraum: 2012-01-04 \u2192 2025-08-29 | n = 3434\n",
       "\n",
       "Vorschau:\n",
       " Price           close  logret_1d  target\n",
@@ -356,7 +364,7 @@
    "source": [
     "# ---- 4) Checks ----\n",
     "print(\"Spalten:\", df_clean.columns.tolist())\n",
-    "print(\"Zeitraum:\", df_clean.index.min().date(), \"→\", df_clean.index.max().date(), \"| n =\", len(df_clean))\n",
+    "print(\"Zeitraum:\", df_clean.index.min().date(), \"\u2192\", df_clean.index.max().date(), \"| n =\", len(df_clean))\n",
     "\n",
     "print(\"\\nVorschau:\\n\", df_clean[[\"close\",\"logret_1d\",\"target\"]].head())\n",
     "\n",
@@ -406,7 +414,7 @@
     }
    ],
    "source": [
-    "# ---- 5) Speichern für Block 3 ----\n",
+    "# ---- 5) Speichern f\u00fcr Block 3 ----\n",
     "csv_out = f\"../data/{TICKER}_{INTERVAL}_{START}_{END}_cls_h{HORIZON}.csv\"\n",
     "df_clean.to_csv(csv_out)\n",
     "print(\"\\nAufbereitete Datei gespeichert unter:\", csv_out)"
@@ -418,8 +426,8 @@
    "metadata": {},
    "source": [
     "# Hinweis zur Leckage:\n",
-    "# Wir haben target ausschließlich aus 'close' gebaut und für die Zukunft per .shift(-HORIZON)\n",
-    "# versetzt. Features, die wir später bauen, dürfen ebenfalls nur Informationen bis t enthalten."
+    "# Wir haben target ausschlie\u00dflich aus 'close' gebaut und f\u00fcr die Zukunft per .shift(-HORIZON)\n",
+    "# versetzt. Features, die wir sp\u00e4ter bauen, d\u00fcrfen ebenfalls nur Informationen bis t enthalten."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- flatten downloaded price DataFrame columns after renaming to guard against MultiIndex headers and enforce consistent index/column names before saving
- simplify the read_prices helper to rely on standard pandas CSV loading while normalising the index, column casing and numeric types
- add a lightweight regression cell that exercises read_prices on both legacy multi-row headers and newly flattened CSV exports

## Testing
- `python - <<'PY'
import pandas as pd
from pathlib import Path
import tempfile

def read_prices(csv_path: str) -> pd.DataFrame:
    df = pd.read_csv(csv_path, index_col=0, parse_dates=[0])
    df.index = pd.to_datetime(df.index, format="%Y-%m-%d", errors="coerce")
    df = df[~df.index.isna()]

    df.columns = [str(c).lower() for c in df.columns]
    df.columns.name = None
    df.index.name = "date"

    keep = ["open", "high", "low", "close", "volume"]
    df = df[[c for c in df.columns if c in keep]].copy()

    for c in df.columns:
        df[c] = pd.to_numeric(df[c], errors="coerce")

    df = df.dropna(how="any")

    return df

legacy_path = Path('data/AAPL_1d_2012-01-01_2025-09-01.csv')
legacy_df = read_prices(legacy_path)
assert not legacy_df.empty
with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
    legacy_df.head().to_csv(tmp.name)
    tmp_path = Path(tmp.name)
try:
    fresh_df = read_prices(tmp_path)
    pd.testing.assert_frame_equal(fresh_df, legacy_df.head())
finally:
    tmp_path.unlink(missing_ok=True)
print('Legacy rows:', legacy_df.shape, '| Fresh rows:', fresh_df.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ceaf8f9bec8321b9e9fa0b664b057b