### PR TITLE
Add validation for price preprocessing

### DIFF
--- a/notebooks/01_data_load.ipynb
+++ b/notebooks/01_data_load.ipynb
@@ -282,6 +282,10 @@
     "    # 3) Index → Datum (alles was kein Datum ist, rausschmeißen)\n",
     "    df.index = pd.to_datetime(df.index, errors=\"coerce\")\n",
     "    df = df[~df.index.isna()]\n",
+    "    df = df.sort_index()\n",
+    "\n",
+    "    if df.index.has_duplicates:\n",
+    "        raise ValueError(\"Duplicate timestamps found in price data\")\n",
     "\n",
     "    # 4) Nur erwartete Spalten behalten\n",
     "    keep = [\"open\", \"high\", \"low\", \"close\", \"volume\"]\n",
@@ -296,7 +300,7 @@
     "\n",
     "    return df\n",
     "\n",
-    "df = read_prices(csv_in)"
+    "df = read_prices(csv_in)\n"
    ]
   },
   {
@@ -307,13 +311,19 @@
    "outputs": [],
    "source": [
     "# ---- 2) Hilfsfeature: 1-Tages-Logreturn (optional) ----\n",
+    "na_counts = df.isna().sum()\n",
+    "assert na_counts.sum() == 0, f\"Remaining NaNs detected: {na_counts[na_counts > 0]}\"\n",
+    "\n",
+    "if (df[\"close\"] <= 0).any():\n",
+    "    raise ValueError(\"Close prices must be positive for log-return computation\")\n",
+    "\n",
     "df[\"logret_1d\"] = np.log(df[\"close\"]).diff()\n",
     "\n",
     "# ---- 3) Zielvariable: Up/Down in HORIZON Schritten ----\n",
     "future_log = np.log(df[\"close\"]).shift(-HORIZON)\n",
     "curr_log   = np.log(df[\"close\"])\n",
     "y_return   = future_log - curr_log\n",
-    "df[\"target\"] = (y_return > 0).astype(int)"
+    "df[\"target\"] = (y_return > 0).astype(int)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- sort price data by timestamp and reject duplicate indices during CSV ingestion
- guard feature creation against non-positive close prices
- assert that no NaN values remain prior to log-based feature engineering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceaf9b03e88321a99fdbb41bc5bcb0