### PR TITLE
Normalise column names when reading price data

### DIFF
--- a/finance_lstm/data.py
+++ b/finance_lstm/data.py
@@ -57,6 +57,11 @@ def read_prices(csv_path: str) -> pd.DataFrame:
     df.index = pd.to_datetime(df.index, errors="coerce")
     df = df[~df.index.isna()]
 
+    # Normalise column names to make the loader resilient against
+    # capitalisation or stray whitespace differences that often occur in
+    # CSV exports from broker platforms.
+    df.columns = [str(col).strip().lower() for col in df.columns]
+
     missing_required = [c for c in MANDATORY_COLUMNS if c not in df.columns]
     if missing_required:
         missing_list = ", ".join(missing_required)

--- a/tests/test_read_prices.py
+++ b/tests/test_read_prices.py
@@ -46,3 +46,28 @@ def test_read_prices_preserves_optional_columns(tmp_path):
 
     assert OPTIONAL_COLUMNS[0] in result.columns
     assert result.shape == df.shape
+
+
+def test_read_prices_normalises_column_names(tmp_path):
+    df = pd.DataFrame(
+        {
+            " Open ": [1.0, 2.0],
+            "HIGH": [2.0, 3.0],
+            "Low": [0.5, 1.5],
+            "Close": [1.5, 2.5],
+            "Volume": [100, 200],
+        },
+        index=pd.Index(["2024-01-01", "2024-01-02"], name="date"),
+    )
+    csv_path = tmp_path / "prices.csv"
+    _write_csv(df, csv_path)
+
+    result = read_prices(csv_path)
+
+    assert set(result.columns) == {
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    }


### PR DESCRIPTION
## Summary
- normalise CSV column names in `read_prices` so uppercase or padded names still satisfy the mandatory checks
- extend the unit test suite with coverage for column name normalisation alongside existing optional-column preservation checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceb4ca1db88321a43dca3f0c5198ee